### PR TITLE
Added deployment bash script, parameters for optional config, address security risks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+.idea_modules/
+atlassian-ide-plugin.xml
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+*.iws
+node_modules/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Create a JSON configuration file `kong.json`:
 		"CreateS3Bucket": "no",
 		"SetDBInstanceIdentifier": "yes",
 		"ElasticsearchLogsStack": "",
+		"VpcCidr": "10.0.0.0/16",
 		"Organization": "changeme",
 		"Team": "changeme",
 		"Environment": "changeme",

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Create a JSON configuration file `kong.json`:
 		"CloudFormationLogGroup": "api-gateway",
 		"CreateS3Bucket": "no",
 		"SetDBInstanceIdentifier": "yes",
+		"ElasticsearchLogsStack": "",
 		"Organization": "changeme",
 		"Team": "changeme",
 		"Environment": "changeme",
@@ -91,6 +92,8 @@ backwards compatibility for existing Cloudformation Stacks:
 2. SetDBInstanceIdentifier: Changing this might cause things
    to break because it might cause the instance to be recreated and change
    the database endpoints.
+3. ElasticsearchLogsStack: Set this to the stack that has a Lambda that
+   can sink data to Elasticsearch
 
 Set the sensitive password in environment variable.
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,26 +1,109 @@
 # Kong API Gateway CloudFormation
 
-A CloudFormation YAML template that provisions a cluster of Kong instances. The CloudFormation template will deploy a highly-available Kong cluster (with scaling policies) backed by AWS RDS PostgreSQL into an existing VPC on AWS. It is meant to be deployed to private subnet(s) and have ELBs residing in the public subnet(s).
+A CloudFormation YAML template that provisions a cluster of Kong instances.
+The CloudFormation template will deploy a highly-available Kong cluster
+(with scaling policies) backed by AWS RDS PostgreSQL into an existing VPC
+on AWS. It is meant to be deployed to private subnet(s) and have ELBs
+residing in the public subnet(s).
 
 ## Features
 
 - Makes use of Cloud Init to provision Kong instances
-  - Configures Kong as a SysVInit service; Can use `service kong start/stop/restart/status`
-  - Enables cfn auto reloader to listen for changes in stack and update instances accordingly
-- Enables use of Kong's Certificate and SNI [features](https://docs.konghq.com/0.13.x/proxy/#configuring-ssl-for-a-route) while being behind ELB
-  - Uses TCP passthrough between ELB and Kong Instances for SSL termination at Kong.
+  - Configures Kong as a SysVInit service; Can use
+    `service kong start/stop/restart/status`
+  - Enables cfn auto reloader to listen for changes in stack and update
+    instances accordingly
+- Enables use of Kong's Certificate and SNI
+  [features](https://docs.konghq.com/0.13.x/proxy/#configuring-ssl-for-a-route)
+  while being behind ELB
+  - Uses TCP passthrough between ELB and Kong Instances for SSL termination
+    at Kong.
   - No need to specify a certificate on ELB. Let Kong handle SSL
 - Optionally Enables SSL access to Kong Instances
 - Optionally enable access to Kong Admin
-  - This can be disabled once you add the Kong Admin as an API and secure it. See [Securing Kong Admin](https://docs.konghq.com/0.13.x/secure-admin-api)
+  - This can be disabled once you add the Kong Admin as an API and secure
+    it. See [Securing Kong Admin](https://docs.konghq.com/0.13.x/secure-admin-api).
 - Forwards CloudFormation logs to an existing Log Group.
-  - Allows easy debugging of cloud formation provisioning without a need to SSH into instances
+  - Allows easy debugging of cloud formation provisioning without a need
+    to SSH into instances
 
 ## Outputs
 
-- ProxyURL - A URL to the Kong Proxy through ELB. You'll want a CNAME pointing to the ELB DNS
-- AdminURL - Access to admin. Only accessible if KongAdminAccessEnabled: true
+- ProxyURL - A URL to the Kong Proxy through ELB. You'll want a CNAME
+  pointing to the ELB DNS
+- AdminURL - Access to admin. Only accessible if `KongAdminAccessEnabled`
+  is set to `true`.
 
 ## Setup
 
-When you first execute the CloudFormation template, make sure you have `RunMigration` enabled which will run key migrations on the Postgres database. You can confirm that everything has run correctly via CloudWatch Logs. Once the process has been complete, you can update the stack and disable `RunMigration`. 
+When you first execute the CloudFormation template, make sure you have
+`RunMigration` enabled which will run key migrations on the Postgres
+database. You can confirm that everything has run correctly via CloudWatch
+Logs. Once the process has been complete, you can update the stack and
+disable `RunMigration`.
+
+### Using the `deploy-stack` script
+
+Create a JSON configuration file `kong.json`:
+
+```json
+{
+	"Parameters": {
+		"VpcId": "vpc-********",
+		"ELBSubnetIds": "subnet-********,subnet-********",
+		"SubnetIds": "subnet-********,subnet-********",
+		"KongVersion": "0.13.1",
+		"KongKeyName": "*********",
+		"KongInstanceType": "m4.large",
+		"SecurityGroupForSSH": "sg-*****************",
+		"KongFleetMinSize": "1",
+		"KongFleetMaxSize": "1",
+		"KongFleetDesiredSize": "1",
+		"HardDriveSize": "50",
+		"DBHost": "",
+		"DBPort": "5432",
+		"DBName": "kong",
+		"DBUsername": "kong",
+		"DBClass": "db.m4.large",
+		"DBVersion": "10.3",
+		"DBMultiAZ": "true",
+		"DBStorageType": "gp2",
+		"DBAllocatedStorage": "5",
+		"DBStorageEncrypted": "false",
+		"KongProxyAccess": "***.***.***.***/32",
+		"KongAdminAccessEnabled": "no",
+		"KinesisStackName": "",
+		"CloudFormationLogGroup": "api-gateway",
+		"CreateS3Bucket": "no",
+		"SetDBInstanceIdentifier": "yes",
+		"Organization": "changeme",
+		"Team": "changeme",
+		"Environment": "changeme",
+		"Component": "API Gateway"
+	}
+}
+```
+
+__NOTE:__ The following parameters have default values to provide
+backwards compatibility for existing Cloudformation Stacks:
+1. CreateS3Bucket: Changing from _yes_ to _no_ will most likely delete
+   the bucket.
+2. SetDBInstanceIdentifier: Changing this might cause things
+   to break because it might cause the instance to be recreated and change
+   the database endpoints.
+
+Set the sensitive password in environment variable.
+```bash
+export SENSITIVE_PARAMS='"DBPassword=changeme"'
+```
+
+The very first deployment will run migrations:
+```bash
+ ./deploy-script kong.cloudformation.yaml dev-api-gateway kong.json yes
+```
+Watch the CloudWatch Logs to see if the migration was successful.
+
+This step will update the stack and start up Kong:
+```bash
+./deploy-script kong.cloudformation.yaml dev-api-gateway kong.json no
+```

--- a/deploy-stack
+++ b/deploy-stack
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+[[ "${DEBUG}" == 'true' ]] && set -o xtrace
+
+prg=$0
+function usage() {
+    echo "Usage:"
+    echo "  $prg <stack path> <stack-name> <path-to-config> <run-migration> TagKey1=TagValue1 TagKey2=TagValue2 ..."
+    echo "    where run-migration=yes|no"
+}
+
+# OSX specific way to get absolute path
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+stack_path=$1
+shift
+if [[ -z "${stack_path}" ]]; then
+    echo "Please specify a path to the CloudFormation template"
+    usage
+    exit 1
+fi
+
+stack_name=$1
+shift
+if [[ -z "${stack_name}" ]]; then
+    echo "Please specify a stack name"
+    usage
+    exit 1
+fi
+
+stack_config=$1
+shift
+if [[ -z "${stack_config}" ]]; then
+    echo "Please specify the path to the parameter configuration file"
+    usage
+    exit 1
+fi
+
+run_migration=$1
+shift
+if [[ -z "${run_migration}" ]]; then
+    echo "Please specify the run-migration parameter"
+    usage
+    exit 1
+fi
+
+# Convert to absolute path
+stack_config=$(realpath ${stack_config})
+
+tags=$@
+
+readonly CFNS=$(grep --include="${stack_path}" --exclude-dir={.idea} -rnwl . -e 'AWSTemplateFormatVersion')
+for cfn in ${CFNS}; do
+    echo "Validating template ${cfn}"
+    ERRORS=$(aws cloudformation validate-template --template-body file://${cfn} | jq .Error)
+
+    if [ "${ERRORS}" != "null" ]; then
+        echo "${cfn} has errors: ${ERRORS}" && exit 1
+    fi
+done
+
+# Need to build the command because --parameter-overrides barfs when there are values with spaces
+# NOTE: SENSITIVE_PARAMS environment can be set to override sensitive key/values.
+#       For example:
+#           SENSITIVE_PARAMS='"Key1=Secret1" "Key2=Secret2"' ./deploy_stack ....
+echo "Deploying template..."
+cmd="aws cloudformation deploy --template-file ${stack_path} --stack-name \"${stack_name}\" --capabilities CAPABILITY_IAM"
+
+if [[ "${run_migration}" == "yes" ]]; then
+    # Set the ASG to 0 instances in order to run migrations
+    params=$(jq -r '.Parameters + {"KongFleetMinSize": "0", "KongFleetDesiredSize": "0", "RunMigration": "yes"} | to_entries | map("\"\(.key)=\(.value|tostring)\"")|.[]' ${stack_config} | tr '\n' ' ')
+else
+    # Simply respect the configuration for the ASG and disable migration run
+    params=$(jq -r '.Parameters + {"RunMigration": "no"} | to_entries | map("\"\(.key)=\(.value|tostring)\"")|.[]' ${stack_config} | tr '\n' ' ')
+fi
+
+if [[ -n ${params} ]]; then
+    cmd="${cmd} --parameter-overrides ${params} ${SENSITIVE_PARAMS}"
+fi
+
+required_tags=$(jq -r '.Parameters | {Organization,Project,Team,Environment,Component} | with_entries(select(.value != null)) | to_entries | map("\"\(.key)=\(.value|tostring)\"") | .[]' ${stack_config} | tr '\n' ' ')
+tags="${tags} ${required_tags}"
+if [[ -n ${tags} ]]; then
+    cmd="${cmd} --tags ${tags}"
+fi
+
+# TODO: Add ability to see changes before commiting to deployment in case there will be a replacement of critical resources like databases
+eval ${cmd}
+
+echo "Deployed stack successfully"

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -184,13 +184,6 @@ Parameters:
     Default: 0.0.0.0/0
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
-  KongAdminAccessEnabled:
-    Default: 'no'
-    Description: Allow public access to Kong Admin
-    Type: String
-    AllowedValues:
-    - 'yes'
-    - 'no'
   KongAdminPort:
     Description: The port at which to expose the Kong Admin dashboard
     Type: String
@@ -199,22 +192,7 @@ Parameters:
     MaxLength: '6'
     AllowedPattern: (\d{2,6})
     ConstraintDescription: must be a valid port
-  KongAdminAccess:
-    Description: The IP address range that can be used to access the Kong Admin port (8001)
-    Type: String
-    MinLength: '9'
-    MaxLength: '18'
-    Default: 0.0.0.0/0
-    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
-  KongAdminAccessSecondary:
-    Description: A secondary IP address range that can be used to access the Kong Admin port
-    Type: String
-    MinLength: '9'
-    MaxLength: '18'
-    Default: 0.0.0.0/0
-    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
-    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+
   # Alarms Configuration
   MinAvgNetworkCapacity:
     Type: String
@@ -323,10 +301,7 @@ Metadata:
       Parameters:
       - ELBSubnetIds
       - KongProxyAccess
-      - KongAdminAccessEnabled
       - KongAdminPort
-      - KongAdminAccess
-      - KongAdminAccessSecondary
     - Label:
         default: "Logging"
       Parameters:
@@ -363,10 +338,6 @@ Mappings:
 
 Conditions:
   CreateRDS: !Equals [!Ref 'DBHost', '']
-  CreateAdminIngress: !Equals [!Ref 'KongAdminAccessEnabled', 'yes']
-  CreateSecondaryAdminIngress: !And
-  - !Not [!Equals [!Ref 'KongAdminAccessSecondary', '0.0.0.0/0']]
-  - !Condition CreateAdminIngress
   CreateSubscriptionFilter: !Not [!Equals [!Ref 'KinesisStackName', '']]
   AllowSSHAccess: !Not [!Equals [!Ref 'SecurityGroupForSSH', '']]
   PerformMigration: !Equals [!Ref RunMigration, 'yes']
@@ -375,6 +346,7 @@ Conditions:
   CreateSubscriptionFilterES: !Not [!Equals [!Ref ElasticsearchLogsStack, '']]
 
 Resources:
+  # Logging
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -383,8 +355,7 @@ Resources:
   SubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     Condition: CreateSubscriptionFilter
-    DependsOn:
-    - LogGroup
+    DependsOn: [LogGroup]
     Properties:
       RoleArn: !ImportValue
         Fn::Sub: ${KinesisStackName}-Role-Arn
@@ -392,13 +363,12 @@ Resources:
       FilterPattern: ''
       DestinationArn: !ImportValue
         Fn::Sub: ${KinesisStackName}-Stream-Arn
-
   SubscriptionFilterES:
     Type: AWS::Logs::SubscriptionFilter
     Condition: CreateSubscriptionFilterES
     DependsOn: [LogGroup]
     Properties:
-      LogGroupName: !Ref LogGroup
+      LogGroupName: !Ref 'LogGroup'
       DestinationArn:
         Fn::ImportValue: !Sub '${ElasticsearchLogsStack}-LambdaFunctionArn'
       FilterPattern: ''
@@ -446,6 +416,7 @@ Resources:
       Path: /
       Roles:
       - !Ref 'KongRole'
+
   # Network Load Balancer
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -505,6 +476,7 @@ Resources:
       HealthCheckProtocol: TCP
       HealthyThresholdCount: 3
       UnhealthyThresholdCount: 3
+
   KongAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     CreationPolicy:
@@ -546,6 +518,7 @@ Resources:
         MinInstancesInService: 2
         PauseTime: PT10M
         WaitOnResourceSignals: true
+
   KongMigrationAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
@@ -576,6 +549,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M
+
   ApiGatewayScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
@@ -592,6 +566,7 @@ Resources:
       Cooldown: '300'
       AutoScalingGroupName: !Ref 'KongAutoScalingGroup'
       ScalingAdjustment: -1
+
   AverageNetworkInHighThresholdAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
@@ -626,6 +601,7 @@ Resources:
       Period: 60
       Statistic: Average
       Threshold: !Ref 'MinAvgNetworkCapacity'
+
   KongLaunchConfig:
     DependsOn:
     - PostgresDB
@@ -1180,25 +1156,6 @@ Resources:
         FromPort: '8001'
         ToPort: '8001'
         CidrIp: !Ref 'VpcCidr'
-  KongAdminIngress:
-    Type: AWS::EC2::SecurityGroupIngress
-    Condition: CreateAdminIngress
-    Properties:
-      GroupId: !GetAtt KongSecurityGroup.GroupId
-      IpProtocol: tcp
-      FromPort: '8001'
-      ToPort: '8001'
-      CidrIp: !Ref 'KongAdminAccess'
-  KongAdminIngressSecondary:
-    Type: AWS::EC2::SecurityGroupIngress
-    Condition: CreateSecondaryAdminIngress
-    Properties:
-      GroupId: !GetAtt KongSecurityGroup.GroupId
-      IpProtocol: tcp
-      FromPort: '8001'
-      ToPort: '8001'
-      CidrIp: !Ref 'KongAdminAccessSecondary'
-
   KongSSHIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: AllowSSHAccess
@@ -1241,7 +1198,7 @@ Resources:
       GroupDescription: Database security groups
       SecurityGroupIngress:
       - IpProtocol: tcp
-        FromPort: 5432
+        FromPort: '5432'
         ToPort: '5432'
         SourceSecurityGroupId: !Ref 'KongSecurityGroup'
       SecurityGroupEgress:
@@ -1250,6 +1207,7 @@ Resources:
         ToPort: '65535'
         CidrIp: 0.0.0.0/0
       VpcId: !Ref 'VpcId'
+
   S3Bucket:
     Type: AWS::S3::Bucket
     Condition: PerformS3BucketCreation
@@ -1260,9 +1218,6 @@ Outputs:
   ProxyURL:
     Description: Kong Proxy URL
     Value: !Join ['', ['https://', !GetAtt [LoadBalancer, DNSName]]]
-  AdminURL:
-    Description: Kong Admin URL
-    Value: !Join ['', ['http://', !GetAtt [LoadBalancer, DNSName], ':', !Ref 'KongAdminPort']]
   S3CertificateBucket:
     Condition: PerformS3BucketCreation
     Value: !Ref 'S3Bucket'

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -236,6 +236,45 @@ Parameters:
     Type: AWS::EC2::VPC::Id
     Description: Required - VPC Id of existing VPC
 
+  CreateS3Bucket:
+    Type: String
+    Description: Create an S3 bucket for the certificates and CI/CD
+    AllowedValues:
+    - 'yes'
+    - 'no'
+    ConstraintDescription: Must be either yes or no
+    Default: 'yes'
+  SetDBInstanceIdentifier:
+    Type: String
+    Description: This will use the Stack name for the Database Identifier; otherwise a random string is used.
+    AllowedValues:
+    - 'yes'
+    - 'no'
+    ConstraintDescription: Must be either yes or no
+    Default: 'no'
+
+  Organization:
+    Type: String
+    Description: Organization tag
+    MinLength: 5
+    ConstraintDescription: Must be a string of length >= 5
+  Team:
+    Type: String
+    Description: Team tag
+    MinLength: 5
+    ConstraintDescription: Must be a string of length >= 5
+  Environment:
+    Type: String
+    Description: Team tag
+    AllowedValues: [dev, sandbox, prod, load, test]
+    ConstraintDescription: Must be one of the available environment types
+  Component:
+    Type: String
+    Description: Component tag
+    MinLength: 3
+    ConstraintDescription: Must be a string of length >= 3
+    Default: 'API Gateway'
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -290,6 +329,13 @@ Metadata:
         default: "Network Configuration"
       Parameters:
       - VpcId
+    - Label:
+        default: "Tags"
+      Parameters:
+      - Organization
+      - Team
+      - Environment
+      - Component
 
     ParameterLabels:
       VpcId:
@@ -317,6 +363,8 @@ Conditions:
   CreateSubscriptionFilter: !Not [!Equals [!Ref 'KinesisStackName', '']]
   AllowSSHAccess: !Not [!Equals [!Ref 'SecurityGroupForSSH', '']]
   PerformMigration: !Equals [!Ref RunMigration, 'yes']
+  PerformS3BucketCreation: !Equals [!Ref CreateS3Bucket, 'yes']
+  SetStackNameForDBInstanceIdentifier: !Equals [!Ref SetDBInstanceIdentifier, 'yes']
 
 Resources:
   LogGroup:
@@ -389,6 +437,14 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub 'Kong NLB - ${AWS::StackName}'
+      - Key: Organization
+        Value: !Ref Organization
+      - Key: Team
+        Value: !Ref Team
+      - Key: Environment
+        Value: !Ref Environment
+      - Key: Component
+        Value: !Ref Component
   ProxyListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -450,7 +506,19 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub '${AWS::StackName} - Instance'
-        PropagateAtLaunch: 'true'
+        PropagateAtLaunch: true
+      - Key: Organization
+        Value: !Ref Organization
+        PropagateAtLaunch: true
+      - Key: Team
+        Value: !Ref Team
+        PropagateAtLaunch: true
+      - Key: Environment
+        Value: !Ref Environment
+        PropagateAtLaunch: true
+      - Key: Component
+        Value: !Ref Component
+        PropagateAtLaunch: true
     UpdatePolicy:
       AutoScalingScheduledAction:
         IgnoreUnmodifiedGroupSizeProperties: 'true'
@@ -470,10 +538,22 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub '${AWS::StackName} - Migration Node Instance'
-        PropagateAtLaunch: 'true'
+        PropagateAtLaunch: true
       - Key: MigrationNode
-        Value: 'true'
-        PropagateAtLaunch: 'true'
+        Value: true
+        PropagateAtLaunch: true
+      - Key: Organization
+        Value: !Ref Organization
+        PropagateAtLaunch: true
+      - Key: Team
+        Value: !Ref Team
+        PropagateAtLaunch: true
+      - Key: Environment
+        Value: !Ref Environment
+        PropagateAtLaunch: true
+      - Key: Component
+        Value: !Ref Component
+        PropagateAtLaunch: true
     CreationPolicy:
       ResourceSignal:
         Timeout: PT15M
@@ -1126,6 +1206,7 @@ Resources:
       StorageType: !Ref 'DBStorageType'
       VPCSecurityGroups:
       - !Ref 'DBSecurityGroup'
+      DBInstanceIdentifier: !If [SetStackNameForDBInstanceIdentifier, !Ref 'AWS::StackName', !Ref 'AWS::NoValue']
   DBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: CreateRDS
@@ -1144,6 +1225,7 @@ Resources:
       VpcId: !Ref 'VpcId'
   S3Bucket:
     Type: AWS::S3::Bucket
+    Condition: PerformS3BucketCreation
     Properties:
       BucketName: !Sub '${AWS::StackName}-certificates'
 
@@ -1155,6 +1237,7 @@ Outputs:
     Description: Kong Admin URL
     Value: !Join ['', ['http://', !GetAtt [LoadBalancer, DNSName], ':', !Ref 'KongAdminPort']]
   S3CertificateBucket:
+    Condition: PerformS3BucketCreation
     Value: !Ref 'S3Bucket'
     Description: URL for the data hosted on S3
   LoadBalancerHostedZoneId:

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -235,6 +235,10 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: Required - VPC Id of existing VPC
+  VpcCidr:
+    Type: String
+    Description: IP range for the VPC
+    Default: 10.0.0.0/16
 
   CreateS3Bucket:
     Type: String
@@ -1168,6 +1172,14 @@ Resources:
         FromPort: '8443'
         ToPort: '8443'
         CidrIp: !Ref 'KongProxyAccess'
+      - IpProtocol: tcp
+        FromPort: '8443'
+        ToPort: '8443'
+        CidrIp: !Ref 'VpcCidr'
+      - IpProtocol: tcp
+        FromPort: '8001'
+        ToPort: '8001'
+        CidrIp: !Ref 'VpcCidr'
   KongAdminIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Condition: CreateAdminIngress

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -252,7 +252,10 @@ Parameters:
     - 'no'
     ConstraintDescription: Must be either yes or no
     Default: 'no'
-
+  ElasticsearchLogsStack:
+    Type: String
+    Description: This will allow creation of a subscription filter that can send logs via a Lambda to Elasticsearch
+    Default: ''
   Organization:
     Type: String
     Description: Organization tag
@@ -365,6 +368,7 @@ Conditions:
   PerformMigration: !Equals [!Ref RunMigration, 'yes']
   PerformS3BucketCreation: !Equals [!Ref CreateS3Bucket, 'yes']
   SetStackNameForDBInstanceIdentifier: !Equals [!Ref SetDBInstanceIdentifier, 'yes']
+  CreateSubscriptionFilterES: !Not [!Equals [!Ref ElasticsearchLogsStack, '']]
 
 Resources:
   LogGroup:
@@ -384,6 +388,17 @@ Resources:
       FilterPattern: ''
       DestinationArn: !ImportValue
         Fn::Sub: ${KinesisStackName}-Stream-Arn
+
+  SubscriptionFilterES:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: CreateSubscriptionFilterES
+    DependsOn: [LogGroup]
+    Properties:
+      LogGroupName: !Ref LogGroup
+      DestinationArn:
+        Fn::ImportValue: !Sub '${ElasticsearchLogsStack}-LambdaFunctionArn'
+      FilterPattern: ''
+
   KongRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
- Added parameters for s3 bucket and database identifier with defauls for backwards compatibility of existing stacks.
- Added deployment bash script to handle staged deployment
- Remove the admin access config and ingress rules from `0.0.0.0/0`, since the administration endpoints aren't secure enough
- Handle health checks properly by allowing access for ELBs via a VpcCIDR configuration.