### PR TITLE
Correct Date Format, reduce the number of requests to Cloudwatch to avoid being Throttled

### DIFF
--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -655,13 +655,13 @@ Resources:
                 file = /usr/local/kong/logs/access.log
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/access.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
+                datetime_format = %Y-%m-%dT%H:%M:%S %z
 
                 [kong-error-log]
                 file = /usr/local/kong/logs/error.log
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/error.log
-                datetime_format = %Y-%m-%dT%H:%M:%SZ
+                datetime_format = %Y-%m-%dT%H:%M:%S %z
 
                 [kong-service-log]
                 file = /var/log/kong.log
@@ -768,10 +768,11 @@ Resources:
                 {
                     missingok
                     notifempty
-                    size 500M
+                    size 5GB
                     create 0600 root root
                     compress
-                    rotate 1
+                    delaycompress
+                    rotate 4
                     postrotate
                             [ ! -f /usr/local/kong/pids/nginx.pid ] || kill -USR1 `cat /usr/local/kong/pids/nginx.pid`
                     endscript

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -795,11 +795,11 @@ Resources:
                 {
                     missingok
                     notifempty
-                    size 50MB
+                    size 1GB
                     create 0600 root root
                     compress
                     delaycompress
-                    rotate 6
+                    rotate 4
                     postrotate
                             [ ! -f /usr/local/kong/pids/nginx.pid ] || kill -USR1 `cat /usr/local/kong/pids/nginx.pid`
                     endscript

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -795,11 +795,11 @@ Resources:
                 {
                     missingok
                     notifempty
-                    size 5GB
+                    size 50MB
                     create 0600 root root
                     compress
                     delaycompress
-                    rotate 4
+                    rotate 6
                     postrotate
                             [ ! -f /usr/local/kong/pids/nginx.pid ] || kill -USR1 `cat /usr/local/kong/pids/nginx.pid`
                     endscript

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -658,13 +658,13 @@ Resources:
                 file = /usr/local/kong/logs/access.log
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/access.log
-                datetime_format = %Y-%m-%dT%H:%M:%S %z
+                datetime_format = %d/%b/%Y:%H:%M:%S %z
 
                 [kong-error-log]
                 file = /usr/local/kong/logs/error.log
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/error.log
-                datetime_format = %Y-%m-%dT%H:%M:%S %z
+                datetime_format = %d/%b/%Y:%H:%M:%S %z
 
                 [kong-service-log]
                 file = /var/log/kong.log

--- a/kong.cloudformation.yaml
+++ b/kong.cloudformation.yaml
@@ -650,6 +650,9 @@ Resources:
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/admin_access.log
                 datetime_format = %Y-%m-%dT%H:%M:%SZ
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [kong-acc-log]
                 file = /usr/local/kong/logs/access.log
@@ -668,48 +671,72 @@ Resources:
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/kong.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [syslog]
                 file = /var/log/messages
                 log_group_name = ${AWS::StackName}
                 log_stream_name = {instance_id}/syslog
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cloud-init.log]
                 file = /var/log/cloud-init.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cloud-init.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cloud-init-output.log]
                 file = /var/log/cloud-init-output.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cloud-init-output.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cfn-init.log]
                 file = /var/log/cfn-init.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cfn-init.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cfn-init-cmd.log]
                 file = /var/log/cfn-init-cmd.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cfn-init-cmd.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cfn-hup.log]
                 file = /var/log/cfn-hup.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cfn-hup.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
                 [/var/log/cfn-wire.log]
                 file = /var/log/cfn-wire.log
                 log_group_name = ${CloudFormationLogGroup}
                 log_stream_name = {instance_id}/cfn-wire.log
                 datetime_format =
+                buffer_duration = 600000
+                batch_count = 10000
+                batch_size = 1048576
 
             "/etc/awslogs/awscli.conf":
               mode: '000444'


### PR DESCRIPTION
*Correct Date Format to the format of Kong Access log*
See https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html and 
Sample Log
```
38.106.204.66 - - [01/Aug/2018:19:56:01 +0000] "GET /?partner=TAPAD&tapad_device_id=42d7cc71-7b02-11e8-bb64-0242ac110009&attribution_id=d5fb34b4-c599-4e
57-8d64-80cb2f773987&impression_id=987d6ed2-c89c-4e01-b554-66616af82372 HTTP/1.1" 200 80 "https://aax-us-east.amazon-adsystem.com/e/dtb/impi?b=IiuztfdWS
GsipyMtiiAmbrEAAAFk9w-1SAEAAA12AcJNn-w&rnd=1228795345771533153392505&pp=14beosg&p=no31ts&crid=2307:lua0t0wy" "Mozilla/5.0 (Windows NT 10.0; Win64; x64)
AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
```
*Reduce the number of Log Request made*
Hard Limit is 5 per second
https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
